### PR TITLE
feat(vote-corrections): add vote-corrections analysis

### DIFF
--- a/vote-corrections/.gitignore
+++ b/vote-corrections/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+*.pyo

--- a/vote-corrections/outputs/output_flourish_table.py
+++ b/vote-corrections/outputs/output_flourish_table.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""
+Convert vote-corrections analysis JSON to a Flourish-ready CSV table.
+
+Columns: id, name, photo, candidate_list, group, constituency,
+         corrections_total, corrections_invalidated, corrections_announced,
+         vote_events_total, correction_rate
+
+Usage:
+    python output_flourish_table.py --input path/to/vote_corrections.json --output path/to/table.csv
+"""
+
+import argparse
+import csv
+import json
+import sys
+
+
+def newest_name(organizations: list[dict], classification: str) -> str:
+    matches = [o for o in organizations if o.get("classification") == classification]
+    if not matches:
+        return ""
+    matches.sort(key=lambda o: o.get("since") or "", reverse=True)
+    return matches[0].get("name") or ""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Convert vote-corrections JSON to a Flourish-ready CSV."
+    )
+    parser.add_argument("--input",  required=True, help="Path to vote-corrections JSON")
+    parser.add_argument("--output", required=True, help="Path to write output CSV")
+    args = parser.parse_args()
+
+    with open(args.input) as f:
+        data = json.load(f)
+
+    fieldnames = [
+        "id",
+        "name",
+        "photo",
+        "candidate_list",
+        "group",
+        "constituency",
+        "corrections_total",
+        "corrections_invalidated",
+        "corrections_announced",
+        "vote_events_total",
+        "correction_rate",
+    ]
+
+    with open(args.output, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in data:
+            orgs = row.get("organizations") or []
+            total = row["corrections_total"]
+            vote_total = row["vote_events_total"]
+            correction_rate = round(total / vote_total, 6) if vote_total > 0 else ""
+            writer.writerow({
+                "id":                     row["person_id"],
+                "name":                   row.get("name") or "",
+                "photo":                  (row.get("extras") or {}).get("image") or "",
+                "candidate_list":         newest_name(orgs, "candidate_list"),
+                "group":                  newest_name(orgs, "group"),
+                "constituency":           newest_name(orgs, "constituency"),
+                "corrections_total":      total,
+                "corrections_invalidated": row["corrections_invalidated"],
+                "corrections_announced":  row["corrections_announced"],
+                "vote_events_total":      vote_total,
+                "correction_rate":        correction_rate,
+            })
+
+    print(f"Wrote {len(data)} rows to {args.output}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/vote-corrections/tests/test_vote_corrections.py
+++ b/vote-corrections/tests/test_vote_corrections.py
@@ -1,0 +1,245 @@
+"""
+Tests for the vote-corrections analysis.
+
+All tests use synthetic in-memory data — no external files required.
+When a real objections dataset exists (e.g. cz-psp-data-2025-202x),
+integration tests can be added following the attendance test pattern.
+
+Run with:
+    python -m pytest legislature-data-analyses/vote-corrections/tests/
+"""
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# Import the analysis module directly
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from vote_corrections import calculate_vote_corrections, parse_date_prefix
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────────
+
+PERSONS = [
+    {"id": "p1", "name": "Alice Novak",   "memberships": {"groups": [{"id": "g1", "name": "Group A"}]}},
+    {"id": "p2", "name": "Bob Dvorak",    "memberships": {"groups": [{"id": "g2", "name": "Group B"}]}},
+    {"id": "p3", "name": "Carol Kratka",  "memberships": {}},
+]
+
+VOTE_EVENTS = [
+    {"id": "ve1", "status": "valid",   "start_date": "2025-01-10"},
+    {"id": "ve2", "status": "invalid", "start_date": "2025-01-11"},  # invalidated
+    {"id": "ve3", "status": "valid",   "start_date": "2025-01-12"},
+    {"id": "ve4", "status": "valid",   "start_date": "2025-01-13"},
+    {"id": "ve5"},                                                    # no status → valid
+]
+
+VOTES = [
+    # p1 voted in ve1, ve2, ve3, ve4
+    {"voter_id": "p1", "vote_event_id": "ve1", "option": "yes"},
+    {"voter_id": "p1", "vote_event_id": "ve2", "option": "yes"},
+    {"voter_id": "p1", "vote_event_id": "ve3", "option": "no"},
+    {"voter_id": "p1", "vote_event_id": "ve4", "option": "yes"},
+    # p2 voted in ve1, ve3
+    {"voter_id": "p2", "vote_event_id": "ve1", "option": "no"},
+    {"voter_id": "p2", "vote_event_id": "ve3", "option": "abstain"},
+    # p3 voted in ve5 only
+    {"voter_id": "p3", "vote_event_id": "ve5", "option": "yes"},
+]
+
+OBJECTIONS = [
+    # p1 corrected ve1 — only announced
+    {"id": "obj1", "vote_event_id": "ve1", "type": "vote_correction",
+     "raised_by_id": "p1", "raised_by_type": "person",
+     "outcome": "announced", "date": "2025-01-10"},
+    # p1 corrected ve2 — led to invalidation
+    {"id": "obj2", "vote_event_id": "ve2", "type": "vote_correction",
+     "raised_by_id": "p1", "raised_by_type": "person",
+     "outcome": "invalidated", "date": "2025-01-11"},
+    # p2 corrected ve3 — announced
+    {"id": "obj3", "vote_event_id": "ve3", "type": "vote_correction",
+     "raised_by_id": "p2", "raised_by_type": "person",
+     "outcome": "announced", "date": "2025-01-12"},
+    # event_objection (not a personal correction) — must be ignored
+    {"id": "obj4", "vote_event_id": "ve4", "type": "event_objection",
+     "raised_by_id": "p1", "raised_by_type": "person",
+     "outcome": "rejected", "date": "2025-01-13"},
+    # correction without raised_by_id — must be ignored
+    {"id": "obj5", "vote_event_id": "ve3", "type": "vote_correction",
+     "outcome": "announced", "date": "2025-01-12"},
+]
+
+
+@pytest.fixture
+def result():
+    return calculate_vote_corrections(
+        OBJECTIONS, VOTE_EVENTS, VOTES, PERSONS,
+        since_date=None, until_date=None,
+    )
+
+
+@pytest.fixture
+def by_id(result):
+    return {r["person_id"]: r for r in result}
+
+
+# ── Basic structure ────────────────────────────────────────────────────────────
+
+class TestOutputStructure:
+    def test_one_row_per_person(self, result):
+        assert len(result) == len(PERSONS)
+
+    def test_required_fields_present(self, result):
+        for row in result:
+            for field in ("person_id", "corrections_total",
+                          "corrections_invalidated", "corrections_announced",
+                          "vote_events_total"):
+                assert field in row, f"Missing field '{field}' in row {row}"
+
+    def test_no_duplicate_person_ids(self, result):
+        ids = [r["person_id"] for r in result]
+        assert len(ids) == len(set(ids))
+
+    def test_all_persons_present(self, result):
+        output_ids = {r["person_id"] for r in result}
+        input_ids  = {p["id"] for p in PERSONS}
+        assert output_ids == input_ids
+
+
+# ── Correction counts ──────────────────────────────────────────────────────────
+
+class TestCorrectionCounts:
+    def test_p1_total(self, by_id):
+        # obj1 (announced) + obj2 (invalidated); obj4 is event_objection → excluded
+        assert by_id["p1"]["corrections_total"] == 2
+
+    def test_p1_invalidated(self, by_id):
+        assert by_id["p1"]["corrections_invalidated"] == 1
+
+    def test_p1_announced(self, by_id):
+        assert by_id["p1"]["corrections_announced"] == 1
+
+    def test_p2_total(self, by_id):
+        assert by_id["p2"]["corrections_total"] == 1
+
+    def test_p2_announced(self, by_id):
+        assert by_id["p2"]["corrections_announced"] == 1
+
+    def test_p3_zero_corrections(self, by_id):
+        assert by_id["p3"]["corrections_total"] == 0
+        assert by_id["p3"]["corrections_invalidated"] == 0
+        assert by_id["p3"]["corrections_announced"] == 0
+
+    def test_event_objection_excluded(self, by_id):
+        # obj4 is type=event_objection — must NOT count for p1
+        assert by_id["p1"]["corrections_total"] == 2  # not 3
+
+    def test_correction_without_raised_by_excluded(self, by_id):
+        # obj5 has no raised_by_id — total for p2 stays 1
+        assert by_id["p2"]["corrections_total"] == 1
+
+    def test_counts_non_negative(self, result):
+        for row in result:
+            assert row["corrections_total"] >= 0
+            assert row["corrections_invalidated"] >= 0
+            assert row["corrections_announced"] >= 0
+
+    def test_invalidated_plus_announced_le_total(self, result):
+        for row in result:
+            assert row["corrections_invalidated"] + row["corrections_announced"] <= row["corrections_total"]
+
+
+# ── Vote events total ──────────────────────────────────────────────────────────
+
+class TestVoteEventsTotal:
+    def test_p1_vote_events_total(self, by_id):
+        # ve1, ve3, ve4 are valid; ve2 is invalid → excluded
+        assert by_id["p1"]["vote_events_total"] == 3
+
+    def test_p2_vote_events_total(self, by_id):
+        # ve1, ve3 valid
+        assert by_id["p2"]["vote_events_total"] == 2
+
+    def test_p3_vote_events_total(self, by_id):
+        # ve5 has no status → treated as valid
+        assert by_id["p3"]["vote_events_total"] == 1
+
+    def test_invalid_events_excluded(self, by_id):
+        # ve2 is invalid; p1 voted there but it must not count
+        assert by_id["p1"]["vote_events_total"] == 3  # not 4
+
+    def test_counts_non_negative(self, result):
+        for row in result:
+            assert row["vote_events_total"] >= 0
+
+
+# ── Date filtering ─────────────────────────────────────────────────────────────
+
+class TestDateFiltering:
+    def test_since_excludes_earlier_events(self):
+        # since 2025-01-12: only ve3 (2025-01-12) and ve4 (2025-01-13) are valid
+        result = calculate_vote_corrections(
+            OBJECTIONS, VOTE_EVENTS, VOTES, PERSONS,
+            since_date=parse_date_prefix("2025-01-12"),
+            until_date=None,
+        )
+        by_id = {r["person_id"]: r for r in result}
+        # p1 voted in ve3, ve4 → 2
+        assert by_id["p1"]["vote_events_total"] == 2
+        # obj1 (2025-01-10) is before since → excluded; obj2 (2025-01-11) excluded
+        assert by_id["p1"]["corrections_total"] == 0
+
+    def test_until_excludes_later_events(self):
+        # until 2025-01-11: ve1 (valid) and ve2 (invalid) are in range
+        result = calculate_vote_corrections(
+            OBJECTIONS, VOTE_EVENTS, VOTES, PERSONS,
+            since_date=None,
+            until_date=parse_date_prefix("2025-01-11"),
+        )
+        by_id = {r["person_id"]: r for r in result}
+        # p1: ve1 valid, ve2 invalid → total=1
+        assert by_id["p1"]["vote_events_total"] == 1
+        # obj1 (2025-01-10 ≤ 2025-01-11) + obj2 (2025-01-11 ≤ 2025-01-11) → 2
+        assert by_id["p1"]["corrections_total"] == 2
+
+    def test_since_until_written_to_output(self):
+        result = calculate_vote_corrections(
+            OBJECTIONS, VOTE_EVENTS, VOTES, PERSONS,
+            since_date=parse_date_prefix("2025-01-01"),
+            until_date=parse_date_prefix("2025-12-31"),
+        )
+        for row in result:
+            assert row.get("since") == "2025-01-01"
+            assert row.get("until") == "2025-12-31"
+
+    def test_no_dates_no_since_until_in_output(self, result):
+        for row in result:
+            assert "since" not in row
+            assert "until" not in row
+
+
+# ── Person metadata pass-through ───────────────────────────────────────────────
+
+class TestPersonMetadata:
+    def test_name_passed_through(self, by_id):
+        assert by_id["p1"]["name"] == "Alice Novak"
+
+    def test_organizations_passed_through(self, by_id):
+        orgs = by_id["p1"].get("organizations", [])
+        assert any(o["id"] == "g1" for o in orgs)
+
+    def test_person_with_no_memberships(self, by_id):
+        # p3 has empty memberships
+        assert by_id["p3"].get("organizations", []) == []
+
+    def test_image_in_extras(self):
+        persons_with_image = [
+            {"id": "px", "name": "Test MP",
+             "image": "https://example.com/photo.jpg", "memberships": {}}
+        ]
+        result = calculate_vote_corrections([], VOTE_EVENTS, [], persons_with_image, None, None)
+        row = result[0]
+        assert row.get("extras", {}).get("image") == "https://example.com/photo.jpg"

--- a/vote-corrections/vote_corrections.py
+++ b/vote-corrections/vote_corrections.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""
+Vote-corrections analysis: per member counts of announced voting corrections
+and resulting vote-event invalidations.
+
+Inputs (all named CLI parameters):
+  --objections   path to vote-event-objections.dt.analyses JSON
+  --votes        path to votes.csv (votes-table.dt format)
+  --vote_events  path to vote-events.dt JSON
+  --persons      path to all-members.dt.analyses JSON or CSV
+  --output       path to write the output JSON
+
+Optional filters:
+  --since        ISO date (YYYY-MM-DD) — ignore vote events before this date
+  --until        ISO date (YYYY-MM-DD) — ignore vote events after this date
+
+Output (one row per person):
+  person_id, name, given_names, family_names, organizations,
+  corrections_total        — times the MP raised a vote_correction
+  corrections_invalidated  — subset where the vote event was invalidated
+  corrections_announced    — subset where it was only noted (outcome=announced)
+  vote_events_total        — valid vote events the MP participated in
+  since, until, extras
+"""
+
+import argparse
+import csv
+import json
+import sys
+from datetime import date, datetime
+from pathlib import Path
+
+import jsonschema
+
+
+# ── Schema paths ───────────────────────────────────────────────────────────────
+
+_SCHEMA_BASE = Path(__file__).parent.parent.parent / "legislature-data-standard" / "dist"
+
+SCHEMA_PATHS = {
+    "objections":  _SCHEMA_BASE / "dt" / "latest" / "schemas" / "vote-event-objections.dt.json",
+    "votes_row":   _SCHEMA_BASE / "dt" / "latest" / "schemas" / "votes-table.dt.json",
+    "vote_events": _SCHEMA_BASE / "dt" / "latest" / "schemas" / "vote-events.dt.json",
+    "persons":     _SCHEMA_BASE / "dt.analyses" / "all-members" / "latest" / "schemas" / "all-members.dt.analyses.json",
+}
+
+
+def load_schema(key: str) -> dict:
+    path = SCHEMA_PATHS[key]
+    with open(path) as f:
+        return json.load(f)
+
+
+# ── Loaders ────────────────────────────────────────────────────────────────────
+
+def load_json_or_csv(path: str) -> list | dict:
+    p = Path(path)
+    suffix = p.suffix.lower()
+    if suffix == ".json":
+        with open(p) as f:
+            return json.load(f)
+    elif suffix == ".csv":
+        with open(p, newline="") as f:
+            return list(csv.DictReader(f))
+    else:
+        raise ValueError(f"Unsupported file extension '{suffix}' for {path}. Expected .json or .csv")
+
+
+def load_objections(path: str) -> list[dict]:
+    data = load_json_or_csv(path)
+    if not isinstance(data, list):
+        sys.exit(f"objections file '{path}' must contain a JSON array")
+    schema = load_schema("objections")
+    try:
+        jsonschema.validate(instance=data, schema=schema)
+    except jsonschema.ValidationError as e:
+        sys.exit(f"objections file '{path}' failed schema validation: {e.message}")
+    return data
+
+
+def load_vote_events(path: str) -> list[dict]:
+    data = load_json_or_csv(path)
+    if not isinstance(data, list):
+        sys.exit(f"vote_events file '{path}' must contain a JSON array")
+    schema = load_schema("vote_events")
+    try:
+        jsonschema.validate(instance=data, schema=schema)
+    except jsonschema.ValidationError as e:
+        sys.exit(f"vote_events file '{path}' failed schema validation: {e.message}")
+    return data
+
+
+def load_votes(path: str) -> list[dict]:
+    data = load_json_or_csv(path)
+    if not isinstance(data, list):
+        sys.exit(f"votes file '{path}' must be a list/array of rows")
+    row_schema = load_schema("votes_row")
+    for i, row in enumerate(data):
+        try:
+            jsonschema.validate(instance=dict(row), schema=row_schema)
+        except jsonschema.ValidationError as e:
+            sys.exit(f"votes file '{path}' row {i} failed schema validation: {e.message}")
+    return data
+
+
+def _parse_memberships_csv(raw: str) -> dict:
+    if not raw or raw.strip() in ("", "{}"):
+        return {}
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+
+
+def load_persons(path: str) -> list[dict]:
+    p = Path(path)
+    if p.suffix.lower() == ".csv":
+        with open(p, newline="") as f:
+            reader = csv.DictReader(f)
+            rows = []
+            for row in reader:
+                person = dict(row)
+                for field in ("identifiers", "sources", "other_names"):
+                    if field in person and person[field]:
+                        try:
+                            person[field] = json.loads(person[field])
+                        except (json.JSONDecodeError, TypeError):
+                            person[field] = []
+                if "memberships" in person:
+                    person["memberships"] = _parse_memberships_csv(person["memberships"])
+                for k, v in person.items():
+                    if v == "":
+                        person[k] = None
+                rows.append(person)
+        data = rows
+    else:
+        with open(p) as f:
+            data = json.load(f)
+
+    if not isinstance(data, list):
+        sys.exit(f"persons file '{path}' must contain an array of persons")
+
+    schema = load_schema("persons")
+    try:
+        jsonschema.validate(instance=data, schema=schema)
+    except jsonschema.ValidationError as e:
+        sys.exit(f"persons file '{path}' failed schema validation: {e.message}")
+    return data
+
+
+# ── Date helpers ───────────────────────────────────────────────────────────────
+
+def parse_date_prefix(s: str | None) -> date | None:
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(s).date()
+    except ValueError:
+        try:
+            return date.fromisoformat(s[:10])
+        except ValueError:
+            return None
+
+
+def in_date_range(event_date: date | None, since: date | None, until: date | None) -> bool:
+    if event_date is None:
+        return True
+    if since is not None and event_date < since:
+        return False
+    if until is not None and event_date > until:
+        return False
+    return True
+
+
+# ── Core calculation ───────────────────────────────────────────────────────────
+
+def calculate_vote_corrections(
+    objections: list[dict],
+    vote_events: list[dict],
+    votes: list[dict],
+    persons: list[dict],
+    since_date: date | None,
+    until_date: date | None,
+) -> list[dict]:
+
+    # Valid vote event IDs within the date range
+    valid_event_ids: set[str] = set()
+    for event in vote_events:
+        status = event.get("status", "valid")
+        if status in ("invalid", "test"):
+            continue
+        event_date = parse_date_prefix(event.get("start_date"))
+        if in_date_range(event_date, since_date, until_date):
+            valid_event_ids.add(event["id"])
+
+    # vote_events_total per person: distinct valid event IDs the person voted in
+    person_events: dict[str, set[str]] = {}
+    for row in votes:
+        vid = row["vote_event_id"]
+        if vid not in valid_event_ids:
+            continue
+        pid = row["voter_id"]
+        person_events.setdefault(pid, set()).add(vid)
+
+    # Filter objections: only vote_correction type, by date range
+    # Group by raised_by_id
+    corrections: dict[str, dict] = {}  # pid -> {total, invalidated, announced}
+    for obj in objections:
+        if obj.get("type") != "vote_correction":
+            continue
+        pid = obj.get("raised_by_id")
+        if not pid:
+            continue
+        obj_date = parse_date_prefix(obj.get("date"))
+        if not in_date_range(obj_date, since_date, until_date):
+            continue
+        if pid not in corrections:
+            corrections[pid] = {"total": 0, "invalidated": 0, "announced": 0}
+        corrections[pid]["total"] += 1
+        outcome = obj.get("outcome")
+        if outcome == "invalidated":
+            corrections[pid]["invalidated"] += 1
+        elif outcome == "announced":
+            corrections[pid]["announced"] += 1
+
+    # Build output rows — one per person from the persons list
+    output: list[dict] = []
+    for person in persons:
+        person_id = person["id"]
+        c = corrections.get(person_id, {"total": 0, "invalidated": 0, "announced": 0})
+        vote_events_total = len(person_events.get(person_id, set()))
+
+        row: dict = {
+            "person_id": person_id,
+            "corrections_total":       c["total"],
+            "corrections_invalidated": c["invalidated"],
+            "corrections_announced":   c["announced"],
+            "vote_events_total":       vote_events_total,
+        }
+
+        if person.get("name"):
+            row["name"] = person["name"]
+        if person.get("given_names") or person.get("given_name"):
+            given = person.get("given_names") or [person["given_name"]]
+            if isinstance(given, str):
+                given = [g.strip() for g in given.split(",") if g.strip()]
+            if given:
+                row["given_names"] = given
+        if person.get("family_names") or person.get("family_name"):
+            family = person.get("family_names") or [person["family_name"]]
+            if isinstance(family, str):
+                family = [f.strip() for f in family.split(",") if f.strip()]
+            if family:
+                row["family_names"] = family
+
+        memberships = person.get("memberships") or {}
+        orgs = []
+        for classification, key in [
+            ("group",          "groups"),
+            ("candidate_list", "candidate_list"),
+            ("constituency",   "constituency"),
+        ]:
+            for g in (memberships.get(key) or []):
+                if not g.get("id"):
+                    continue
+                org: dict = {"id": g["id"], "classification": classification}
+                if g.get("name"):
+                    org["name"] = g["name"]
+                start = g.get("start_date")
+                end   = g.get("end_date")
+                if start:
+                    org["since"] = start[:10]
+                if end:
+                    org["until"] = end[:10]
+                orgs.append(org)
+        if orgs:
+            row["organizations"] = orgs
+
+        if since_date is not None:
+            row["since"] = since_date.isoformat()
+        if until_date is not None:
+            row["until"] = until_date.isoformat()
+
+        extras: dict = {}
+        if person.get("image"):
+            extras["image"] = person["image"]
+        if extras:
+            row["extras"] = extras
+
+        output.append(row)
+
+    return output
+
+
+# ── Entry point ────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Calculate vote-correction counts per member."
+    )
+    parser.add_argument("--objections",  required=True, help="Path to vote-event-objections JSON")
+    parser.add_argument("--votes",       required=True, help="Path to votes CSV or JSON")
+    parser.add_argument("--vote_events", required=True, help="Path to vote-events JSON")
+    parser.add_argument("--persons",     required=True, help="Path to all-members JSON or CSV")
+    parser.add_argument("--output",      required=True, help="Path to write output JSON")
+    parser.add_argument("--since",       default=None,  help="Start date filter (YYYY-MM-DD)")
+    parser.add_argument("--until",       default=None,  help="End date filter (YYYY-MM-DD)")
+    args = parser.parse_args()
+
+    since_date = parse_date_prefix(args.since)
+    until_date = parse_date_prefix(args.until)
+
+    print("Loading and validating objections...", file=sys.stderr)
+    objections = load_objections(args.objections)
+
+    print("Loading and validating vote_events...", file=sys.stderr)
+    vote_events = load_vote_events(args.vote_events)
+
+    print("Loading and validating votes...", file=sys.stderr)
+    votes = load_votes(args.votes)
+
+    print("Loading and validating persons...", file=sys.stderr)
+    persons = load_persons(args.persons)
+
+    print("Calculating vote corrections...", file=sys.stderr)
+    output = calculate_vote_corrections(
+        objections, vote_events, votes, persons, since_date, until_date
+    )
+
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w") as f:
+        json.dump(output, f, ensure_ascii=False, indent=2)
+
+    print(f"Done. Wrote {len(output)} records to {args.output}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `vote-corrections/` analysis: per-member counts of announced voting corrections and resulting invalidations
- Self-contained, mirrors the attendance analysis pattern

## Outputs per person
- `corrections_total`: times the MP raised a `vote_correction`
- `corrections_invalidated`: subset where the vote event was invalidated
- `corrections_announced`: subset where it was only noted for the record
- `vote_events_total`: valid vote events the MP participated in (independent from objections data)

## Scripts
- `vote_corrections.py`: main analysis, validates inputs against DT schemas, `--since`/`--until` filters
- `outputs/output_flourish_table.py`: Flourish-ready CSV with photo, orgs, correction_rate
- `tests/test_vote_corrections.py`: 27 unit tests, fully self-contained (synthetic data, no external files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)