### PR TITLE
feat: split rebelity and govity into separate analyses

### DIFF
--- a/govity/.gitignore
+++ b/govity/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/

--- a/govity/govity.py
+++ b/govity/govity.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""
+Govity analysis: per-member rate of voting with the government.
+
+Inputs (all named CLI parameters):
+  --definition   path to govity-definition.dt.analyses JSON
+  --votes        path to votes.csv (votes-table.dt format)
+  --vote_events  path to vote-events.dt JSON
+  --persons      path to all-members.dt.analyses JSON or CSV
+  --output       path to write the govity.dt.analyses output JSON
+
+Optional:
+  --since        ISO date (YYYY-MM-DD) — overrides definition's since
+  --until        ISO date (YYYY-MM-DD) — overrides definition's until
+
+Output (one row per person):
+  person_id, name, given_names, family_names, organizations,
+  govity_total, govity_possible, govity,
+  since, until, extras
+
+Vote semantics (from definition):
+  yes_options    → vote_value = +1, active = +1
+  no_options     → vote_value = -1, active = -1
+  other present  → vote_value = -1 (counts against for direction), active = 0
+  absent_options → vote_value =  0, not present
+
+Government direction per vote event = sign(sum of vote_values for all government members).
+Govity denominator = vote events where government had a clear direction AND the MP was present.
+Govity numerator   = subset where MP was present and did NOT actively vote against the government.
+"""
+
+import argparse
+import csv
+import json
+import sys
+from datetime import date, datetime
+from pathlib import Path
+
+import jsonschema
+
+
+# ── Schema paths ───────────────────────────────────────────────────────────────
+
+_SCHEMA_BASE = Path(__file__).parent.parent.parent / "legislature-data-standard" / "dist"
+
+SCHEMA_PATHS = {
+    "definition":  _SCHEMA_BASE / "dt.analyses" / "govity-definition" / "latest" / "schemas" / "govity-definition.dt.analyses.json",
+    "votes_row":   _SCHEMA_BASE / "dt" / "latest" / "schemas" / "votes-table.dt.json",
+    "vote_events": _SCHEMA_BASE / "dt" / "latest" / "schemas" / "vote-events.dt.json",
+    "persons":     _SCHEMA_BASE / "dt.analyses" / "all-members" / "latest" / "schemas" / "all-members.dt.analyses.json",
+}
+
+
+def load_schema(key: str) -> dict:
+    path = SCHEMA_PATHS[key]
+    with open(path) as f:
+        return json.load(f)
+
+
+# ── Loaders ────────────────────────────────────────────────────────────────────
+
+def load_json_or_csv(path: str) -> list | dict:
+    p = Path(path)
+    suffix = p.suffix.lower()
+    if suffix == ".json":
+        with open(p) as f:
+            return json.load(f)
+    elif suffix == ".csv":
+        with open(p, newline="") as f:
+            return list(csv.DictReader(f))
+    else:
+        raise ValueError(f"Unsupported extension '{suffix}' for {path}")
+
+
+def load_definition(path: str) -> dict:
+    with open(path) as f:
+        data = json.load(f)
+    schema = load_schema("definition")
+    try:
+        jsonschema.validate(instance=data, schema=schema)
+    except jsonschema.ValidationError as e:
+        sys.exit(f"Definition '{path}' failed schema validation: {e.message}")
+    return data
+
+
+def load_vote_events(path: str) -> list[dict]:
+    data = load_json_or_csv(path)
+    if not isinstance(data, list):
+        sys.exit(f"vote_events '{path}' must be a JSON array")
+    schema = load_schema("vote_events")
+    try:
+        jsonschema.validate(instance=data, schema=schema)
+    except jsonschema.ValidationError as e:
+        sys.exit(f"vote_events '{path}' failed schema validation: {e.message}")
+    return data
+
+
+def load_votes(path: str) -> list[dict]:
+    data = load_json_or_csv(path)
+    if not isinstance(data, list):
+        sys.exit(f"votes '{path}' must be a list/array")
+    row_schema = load_schema("votes_row")
+    for i, row in enumerate(data):
+        try:
+            jsonschema.validate(instance=dict(row), schema=row_schema)
+        except jsonschema.ValidationError as e:
+            sys.exit(f"votes '{path}' row {i} failed schema validation: {e.message}")
+    return data
+
+
+def _parse_memberships_csv(raw: str) -> dict:
+    if not raw or raw.strip() in ("", "{}"):
+        return {}
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+
+
+def load_persons(path: str) -> list[dict]:
+    p = Path(path)
+    if p.suffix.lower() == ".csv":
+        with open(p, newline="") as f:
+            rows = []
+            for row in csv.DictReader(f):
+                person = dict(row)
+                for field in ("identifiers", "sources", "other_names"):
+                    if field in person and person[field]:
+                        try:
+                            person[field] = json.loads(person[field])
+                        except (json.JSONDecodeError, TypeError):
+                            person[field] = []
+                if "memberships" in person:
+                    person["memberships"] = _parse_memberships_csv(person["memberships"])
+                for k, v in person.items():
+                    if v == "":
+                        person[k] = None
+                rows.append(person)
+        data = rows
+    else:
+        with open(p) as f:
+            data = json.load(f)
+    if not isinstance(data, list):
+        sys.exit(f"persons '{path}' must be an array")
+    schema = load_schema("persons")
+    try:
+        jsonschema.validate(instance=data, schema=schema)
+    except jsonschema.ValidationError as e:
+        sys.exit(f"persons '{path}' failed schema validation: {e.message}")
+    return data
+
+
+# ── Date helpers ───────────────────────────────────────────────────────────────
+
+def parse_date_prefix(s: str | None) -> date | None:
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(s).date()
+    except ValueError:
+        try:
+            return date.fromisoformat(s[:10])
+        except ValueError:
+            return None
+
+
+def in_date_range(d: date | None, since: date | None, until: date | None) -> bool:
+    if d is None:
+        return True
+    if since is not None and d < since:
+        return False
+    if until is not None and d > until:
+        return False
+    return True
+
+
+# ── Group membership lookup ────────────────────────────────────────────────────
+
+def build_group_memberships(persons: list[dict]) -> dict[str, list[tuple]]:
+    result: dict[str, list[tuple]] = {}
+    for p in persons:
+        pid = p.get("id") or p.get("person_id", "")
+        groups = (p.get("memberships") or {}).get("groups") or []
+        entries = []
+        for g in groups:
+            gid = g.get("id")
+            if not gid:
+                continue
+            entries.append((gid, parse_date_prefix(g.get("start_date")), parse_date_prefix(g.get("end_date"))))
+        entries.sort(key=lambda t: t[1] or date.min, reverse=True)
+        result[pid] = entries
+    return result
+
+
+def get_group_at_date(person_id: str, event_date: date | None,
+                      group_memberships: dict[str, list[tuple]]) -> str | None:
+    for (gid, start, end) in group_memberships.get(person_id, []):
+        if event_date is not None:
+            if start is not None and event_date < start:
+                continue
+            if end is not None and event_date > end:
+                continue
+        return gid
+    return None
+
+
+# ── Vote value helpers ─────────────────────────────────────────────────────────
+
+def vote_value(option: str, yes_opts: set[str], no_opts: set[str], present_opts: set[str]) -> int:
+    if option in yes_opts:
+        return 1
+    if option in no_opts:
+        return -1
+    if option in present_opts:
+        return -1
+    return 0
+
+
+def vote_value_active(option: str, yes_opts: set[str], no_opts: set[str]) -> int:
+    if option in yes_opts:
+        return 1
+    if option in no_opts:
+        return -1
+    return 0
+
+
+# ── Core calculation ───────────────────────────────────────────────────────────
+
+def calculate_govity(
+    definition: dict,
+    vote_events: list[dict],
+    votes: list[dict],
+    persons: list[dict],
+    since_override: date | None,
+    until_override: date | None,
+) -> list[dict]:
+
+    since_date = since_override or parse_date_prefix(definition.get("since"))
+    until_date = until_override or parse_date_prefix(definition.get("until"))
+    present_opts = set(definition["present_options"])
+    yes_opts = set(definition["yes_options"])
+    no_opts  = set(definition["no_options"])
+    gov_groups  = set(definition.get("government_groups") or [])
+    gov_members = set(definition.get("government_members") or [])
+
+    group_memberships = build_group_memberships(persons)
+
+    def is_in_government(person_id: str, event_date: date | None) -> bool:
+        if person_id in gov_members:
+            return True
+        gid = get_group_at_date(person_id, event_date, group_memberships)
+        return gid in gov_groups if gid else False
+
+    # Filter valid vote events
+    valid_events: dict[str, date | None] = {}
+    for ev in vote_events:
+        if ev.get("status", "valid") in ("invalid", "test"):
+            continue
+        ev_date = parse_date_prefix(ev.get("start_date"))
+        if in_date_range(ev_date, since_date, until_date):
+            valid_events[ev["id"]] = ev_date
+
+    # Index votes
+    votes_by_event: dict[str, list[tuple[str, str]]] = {}
+    person_vote: dict[str, dict[str, str]] = {}
+    for row in votes:
+        eid = row["vote_event_id"]
+        if eid not in valid_events:
+            continue
+        pid, opt = row["voter_id"], row["option"]
+        votes_by_event.setdefault(eid, []).append((pid, opt))
+        person_vote.setdefault(pid, {})[eid] = opt
+
+    # Compute government direction per event
+    gov_direction: dict[str, int] = {}
+    for eid, ev_date in valid_events.items():
+        gov_sum = 0
+        for (pid, opt) in votes_by_event.get(eid, []):
+            if is_in_government(pid, ev_date):
+                gov_sum += vote_value(opt, yes_opts, no_opts, present_opts)
+        gov_direction[eid] = 1 if gov_sum > 0 else (-1 if gov_sum < 0 else 0)
+
+    # Build output
+    output: list[dict] = []
+    for person in persons:
+        pid = person.get("id") or person.get("person_id", "")
+        govity_total    = 0
+        govity_possible = 0
+        p_votes = person_vote.get(pid, {})
+
+        for eid, ev_date in valid_events.items():
+            gvdir = gov_direction.get(eid, 0)
+            if gvdir == 0:
+                continue
+            opt = p_votes.get(eid)
+            if opt is not None and opt in present_opts:
+                govity_possible += 1
+                active = vote_value_active(opt, yes_opts, no_opts)
+                if active * gvdir != -1:
+                    govity_total += 1
+
+        row: dict = {
+            "person_id":      pid,
+            "govity_total":    govity_total,
+            "govity_possible": govity_possible,
+            "govity":          round(govity_total / govity_possible, 6) if govity_possible > 0 else None,
+        }
+
+        if person.get("name"):
+            row["name"] = person["name"]
+        if person.get("given_names") or person.get("given_name"):
+            given = person.get("given_names") or [person["given_name"]]
+            if isinstance(given, str):
+                given = [g.strip() for g in given.split(",") if g.strip()]
+            if given:
+                row["given_names"] = given
+        if person.get("family_names") or person.get("family_name"):
+            family = person.get("family_names") or [person["family_name"]]
+            if isinstance(family, str):
+                family = [f.strip() for f in family.split(",") if f.strip()]
+            if family:
+                row["family_names"] = family
+
+        memberships = person.get("memberships") or {}
+        orgs = []
+        for classification, key in [("group", "groups"), ("candidate_list", "candidate_list"), ("constituency", "constituency")]:
+            for g in (memberships.get(key) or []):
+                if not g.get("id"):
+                    continue
+                org: dict = {"id": g["id"], "classification": classification}
+                if g.get("name"):
+                    org["name"] = g["name"]
+                if g.get("start_date"):
+                    org["since"] = g["start_date"][:10]
+                if g.get("end_date"):
+                    org["until"] = g["end_date"][:10]
+                orgs.append(org)
+        if orgs:
+            row["organizations"] = orgs
+
+        if since_date is not None:
+            row["since"] = since_date.isoformat()
+        if until_date is not None:
+            row["until"] = until_date.isoformat()
+
+        extras: dict = {}
+        if person.get("image"):
+            extras["image"] = person["image"]
+        if extras:
+            row["extras"] = extras
+
+        output.append(row)
+
+    return output
+
+
+# ── Entry point ────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--definition",  required=True)
+    parser.add_argument("--votes",       required=True)
+    parser.add_argument("--vote_events", required=True)
+    parser.add_argument("--persons",     required=True)
+    parser.add_argument("--output",      required=True)
+    parser.add_argument("--since",       default=None)
+    parser.add_argument("--until",       default=None)
+    args = parser.parse_args()
+
+    since_override = parse_date_prefix(args.since)
+    until_override = parse_date_prefix(args.until)
+
+    print("Loading definition...",  file=sys.stderr)
+    definition = load_definition(args.definition)
+    print("Loading vote_events...", file=sys.stderr)
+    vote_events = load_vote_events(args.vote_events)
+    print("Loading votes...",       file=sys.stderr)
+    votes = load_votes(args.votes)
+    print("Loading persons...",     file=sys.stderr)
+    persons = load_persons(args.persons)
+    print("Calculating...",         file=sys.stderr)
+    output = calculate_govity(definition, vote_events, votes, persons, since_override, until_override)
+
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w") as f:
+        json.dump(output, f, ensure_ascii=False, indent=2)
+    print(f"Done. Wrote {len(output)} records to {args.output}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/govity/outputs/output_flourish_table.py
+++ b/govity/outputs/output_flourish_table.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""
+Convert govity.dt.analyses JSON to a Flourish-ready CSV table.
+
+Columns: id, name, photo, candidate_list, group, constituency,
+         govity, govity_percent, govity_total, govity_possible
+
+Usage:
+    python output_flourish_table.py --input path/to/govity.json --output path/to/table.csv
+"""
+
+import argparse
+import csv
+import json
+import sys
+
+
+def newest_name(organizations: list[dict], classification: str) -> str:
+    """Return the name of the most recently started org of the given classification."""
+    matches = [o for o in organizations if o.get("classification") == classification]
+    if not matches:
+        return ""
+    matches.sort(key=lambda o: o.get("since") or "", reverse=True)
+    return matches[0].get("name") or ""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Convert govity JSON to a Flourish-ready CSV."
+    )
+    parser.add_argument("--input",  required=True, help="Path to govity.dt.analyses JSON")
+    parser.add_argument("--output", required=True, help="Path to write output CSV")
+    args = parser.parse_args()
+
+    with open(args.input) as f:
+        data = json.load(f)
+
+    fieldnames = [
+        "id",
+        "name",
+        "photo",
+        "candidate_list",
+        "group",
+        "constituency",
+        "govity",
+        "govity_percent",
+        "govity_total",
+        "govity_possible",
+    ]
+
+    with open(args.output, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in data:
+            orgs = row.get("organizations") or []
+            gv = row.get("govity")
+            writer.writerow({
+                "id":             row["person_id"],
+                "name":           row.get("name") or "",
+                "photo":          (row.get("extras") or {}).get("image") or "",
+                "candidate_list": newest_name(orgs, "candidate_list"),
+                "group":          newest_name(orgs, "group"),
+                "constituency":   newest_name(orgs, "constituency"),
+                "govity":         gv if gv is not None else "",
+                "govity_percent": round(gv * 100, 1) if gv is not None else "",
+                "govity_total":    row["govity_total"],
+                "govity_possible": row["govity_possible"],
+            })
+
+    print(f"Wrote {len(data)} rows to {args.output}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/govity/tests/test_govity.py
+++ b/govity/tests/test_govity.py
@@ -1,0 +1,242 @@
+"""
+Tests for the govity analysis.
+
+Run with:
+    python -m pytest legislature-data-analyses/govity/tests/
+or from the govity directory:
+    python -m pytest tests/
+"""
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+# ── Path constants ─────────────────────────────────────────────────────────────
+
+REPO_ROOT = Path(__file__).parent.parent.parent.parent  # legislature-data/
+GOVITY_SCRIPT = Path(__file__).parent.parent / "govity.py"
+
+# Test data paths (CZ PSP 2025-202x)
+_LEGISLATURE    = REPO_ROOT / "legislatures" / "cz-psp-data-2025-202x"
+TEST_DEFINITION  = _LEGISLATURE / "analyses" / "govity" / "govity_definition.json"
+TEST_VOTES       = _LEGISLATURE / "work" / "standard" / "votes.csv"
+TEST_VOTE_EVENTS = _LEGISLATURE / "work" / "standard" / "vote_events.json"
+TEST_PERSONS     = _LEGISLATURE / "analyses" / "all-members" / "outputs" / "all_members.json"
+
+# Output schema path
+_SCHEMA_BASE = REPO_ROOT / "legislature-data-standard" / "dist"
+OUTPUT_SCHEMA_PATH = _SCHEMA_BASE / "dt.analyses" / "govity" / "latest" / "schemas" / "govity.dt.analyses.json"
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def run_script(*extra_args, output_path: Path | None = None) -> tuple[int, str, str, list[dict] | None]:
+    """Run the govity script and return (returncode, stdout, stderr, parsed_output)."""
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tmp:
+        out = Path(tmp.name) if output_path is None else output_path
+
+    cmd = [
+        sys.executable, str(GOVITY_SCRIPT),
+        "--definition",  str(TEST_DEFINITION),
+        "--votes",       str(TEST_VOTES),
+        "--vote_events", str(TEST_VOTE_EVENTS),
+        "--persons",     str(TEST_PERSONS),
+        "--output",      str(out),
+        *extra_args,
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    data = None
+    if result.returncode == 0 and out.exists():
+        with open(out) as f:
+            data = json.load(f)
+    return result.returncode, result.stdout, result.stderr, data
+
+
+@pytest.fixture(scope="module")
+def output_data() -> list[dict]:
+    """Run the script once and return the output for all tests in this module."""
+    rc, stdout, stderr, data = run_script()
+    assert rc == 0, f"Script failed:\nSTDOUT: {stdout}\nSTDERR: {stderr}"
+    assert data is not None, "No output data produced"
+    return data
+
+
+@pytest.fixture(scope="module")
+def definition() -> dict:
+    with open(TEST_DEFINITION) as f:
+        return json.load(f)
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────────
+
+class TestOutputNotEmpty:
+    def test_has_persons(self, output_data):
+        """Output must contain at least one person."""
+        assert len(output_data) > 0, "Output is empty – expected at least one govity record"
+
+    def test_has_many_persons(self, output_data):
+        """Sanity check: Czech parliament has ~200 members."""
+        assert len(output_data) >= 100, f"Expected >=100 records, got {len(output_data)}"
+
+
+class TestOutputSchema:
+    def test_validates_against_schema(self, output_data):
+        """Output must validate against govity.dt.analyses JSON schema."""
+        with open(OUTPUT_SCHEMA_PATH) as f:
+            schema = json.load(f)
+        jsonschema.validate(instance=output_data, schema=schema)
+
+    def test_required_fields_present(self, output_data):
+        """Every row must have person_id, govity_total, govity_possible."""
+        for i, row in enumerate(output_data):
+            for field in ("person_id", "govity_total", "govity_possible"):
+                assert field in row, f"Row {i} missing required field '{field}'"
+
+
+class TestGovityCounts:
+    def test_counts_non_negative(self, output_data):
+        """govity_total and govity_possible must be non-negative integers."""
+        for row in output_data:
+            assert row["govity_total"] >= 0
+            assert row["govity_possible"] >= 0
+
+    def test_total_le_possible(self, output_data):
+        """govity_total must not exceed govity_possible."""
+        for row in output_data:
+            assert row["govity_total"] <= row["govity_possible"], (
+                f"Person {row['person_id']}: govity_total ({row['govity_total']}) "
+                f"> govity_possible ({row['govity_possible']})"
+            )
+
+    def test_govity_rate_range(self, output_data):
+        """govity must be between 0 and 1 inclusive (or null when possible=0)."""
+        for row in output_data:
+            gv = row.get("govity")
+            if gv is not None:
+                assert 0.0 <= gv <= 1.0, (
+                    f"Person {row['person_id']}: govity {gv} out of [0,1]"
+                )
+
+    def test_govity_null_when_possible_zero(self, output_data):
+        """If govity_possible == 0, govity must be null."""
+        for row in output_data:
+            if row["govity_possible"] == 0:
+                assert row.get("govity") is None, (
+                    f"Person {row['person_id']}: govity should be null when possible=0"
+                )
+
+    def test_govity_consistent(self, output_data):
+        """govity must equal govity_total / govity_possible (within tolerance)."""
+        for row in output_data:
+            possible = row["govity_possible"]
+            gv = row.get("govity")
+            if possible > 0:
+                expected = row["govity_total"] / possible
+                assert gv is not None
+                assert abs(gv - round(expected, 6)) < 1e-9, (
+                    f"Person {row['person_id']}: govity {gv} != {expected}"
+                )
+
+    def test_possible_varies_across_persons(self, output_data):
+        """govity_possible should differ across persons (MPs absent from some events)."""
+        possibles = {row["govity_possible"] for row in output_data}
+        assert len(possibles) > 1, (
+            "govity_possible is identical for all persons – expected variation"
+        )
+
+
+class TestGovernmentMembers:
+    def test_government_members_have_high_govity(self, output_data, definition):
+        """Government group members should have govity > 0.9 on average."""
+        gov_groups = set(definition.get("government_groups") or [])
+        gov_rows = [
+            row for row in output_data
+            if any(
+                o.get("id") in gov_groups and o.get("classification") == "group"
+                for o in (row.get("organizations") or [])
+            )
+            and row.get("govity") is not None
+        ]
+        if gov_rows:
+            avg = sum(r["govity"] for r in gov_rows) / len(gov_rows)
+            assert avg > 0.9, (
+                f"Government members' average govity is {avg:.3f}, expected > 0.9"
+            )
+
+
+class TestPersonCoverage:
+    def test_all_input_persons_in_output(self, output_data):
+        """Every person from the persons input must appear in the output."""
+        with open(TEST_PERSONS) as f:
+            persons = json.load(f)
+        input_ids = {p["id"] for p in persons}
+        output_ids = {row["person_id"] for row in output_data}
+        missing = input_ids - output_ids
+        assert missing == set(), f"These persons are missing from output: {missing}"
+
+    def test_no_duplicate_person_ids(self, output_data):
+        """Each person_id must appear at most once in the output."""
+        ids = [row["person_id"] for row in output_data]
+        duplicates = {pid for pid in ids if ids.count(pid) > 1}
+        assert duplicates == set(), f"Duplicate person_ids in output: {duplicates}"
+
+    def test_no_extra_persons_in_output(self, output_data):
+        """Output should not contain persons that were not in the persons input."""
+        with open(TEST_PERSONS) as f:
+            persons = json.load(f)
+        input_ids = {p["id"] for p in persons}
+        output_ids = {row["person_id"] for row in output_data}
+        extra = output_ids - input_ids
+        assert extra == set(), f"Output contains persons not in input: {extra}"
+
+
+class TestOrganizations:
+    def test_organization_ids_are_strings(self, output_data):
+        """All organization entries must have a non-empty string id."""
+        for row in output_data:
+            for org in row.get("organizations", []):
+                assert isinstance(org["id"], str) and org["id"], (
+                    f"Person {row['person_id']}: org with invalid id: {org}"
+                )
+
+
+class TestExtras:
+    def test_image_url_when_present(self, output_data):
+        """If extras.image is set it must be a non-empty string."""
+        for row in output_data:
+            extras = row.get("extras") or {}
+            image = extras.get("image")
+            if image is not None:
+                assert isinstance(image, str) and image, (
+                    f"Person {row['person_id']}: extras.image must be a non-empty string"
+                )
+
+    def test_some_persons_have_image(self, output_data):
+        """At least one person should carry an image URL from the persons input."""
+        images = [
+            row["extras"]["image"]
+            for row in output_data
+            if (row.get("extras") or {}).get("image")
+        ]
+        assert len(images) > 0, "No person has an image URL – check that persons input includes 'image' fields"
+
+
+class TestDateOverride:
+    def test_since_override_filters_events(self):
+        """--since flag should reduce or maintain the number of vote events counted."""
+        _, _, _, data_all = run_script()
+        _, _, _, data_since = run_script("--since", "2026-01-01")
+        assert data_since is not None
+
+        id_to_all = {r["person_id"]: r for r in data_all}
+        for row in data_since:
+            pid = row["person_id"]
+            if pid in id_to_all:
+                assert row["govity_possible"] <= id_to_all[pid]["govity_possible"], (
+                    f"Person {pid}: govity_possible increased with --since filter"
+                )

--- a/rebelity/.gitignore
+++ b/rebelity/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/

--- a/rebelity/outputs/output_flourish_table.py
+++ b/rebelity/outputs/output_flourish_table.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""
+Convert rebelity.dt.analyses JSON to a Flourish-ready CSV table.
+
+Columns: id, name, photo, candidate_list, group, constituency,
+         rebelity, rebelity_percent, rebelity_total, rebelity_possible
+
+Usage:
+    python output_flourish_table.py --input path/to/rebelity.json --output path/to/table.csv
+"""
+
+import argparse
+import csv
+import json
+import sys
+
+
+def newest_name(organizations: list[dict], classification: str) -> str:
+    """Return the name of the most recently started org of the given classification."""
+    matches = [o for o in organizations if o.get("classification") == classification]
+    if not matches:
+        return ""
+    matches.sort(key=lambda o: o.get("since") or "", reverse=True)
+    return matches[0].get("name") or ""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Convert rebelity JSON to a Flourish-ready CSV."
+    )
+    parser.add_argument("--input",  required=True, help="Path to rebelity.dt.analyses JSON")
+    parser.add_argument("--output", required=True, help="Path to write output CSV")
+    args = parser.parse_args()
+
+    with open(args.input) as f:
+        data = json.load(f)
+
+    fieldnames = [
+        "id",
+        "name",
+        "photo",
+        "candidate_list",
+        "group",
+        "constituency",
+        "rebelity",
+        "rebelity_percent",
+        "rebelity_total",
+        "rebelity_possible",
+    ]
+
+    with open(args.output, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in data:
+            orgs = row.get("organizations") or []
+            rb = row.get("rebelity")
+            writer.writerow({
+                "id":                row["person_id"],
+                "name":              row.get("name") or "",
+                "photo":             (row.get("extras") or {}).get("image") or "",
+                "candidate_list":    newest_name(orgs, "candidate_list"),
+                "group":             newest_name(orgs, "group"),
+                "constituency":      newest_name(orgs, "constituency"),
+                "rebelity":          rb if rb is not None else "",
+                "rebelity_percent":  round(rb * 100, 1) if rb is not None else "",
+                "rebelity_total":    row["rebelity_total"],
+                "rebelity_possible": row["rebelity_possible"],
+            })
+
+    print(f"Wrote {len(data)} rows to {args.output}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/rebelity/rebelity.py
+++ b/rebelity/rebelity.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""
+Rebelity analysis: per-member rate of voting against own group's majority.
+
+Inputs (all named CLI parameters):
+  --definition   path to rebelity-definition.dt.analyses JSON
+  --votes        path to votes.csv (votes-table.dt format)
+  --vote_events  path to vote-events.dt JSON
+  --persons      path to all-members.dt.analyses JSON or CSV
+  --output       path to write the rebelity.dt.analyses output JSON
+
+Optional:
+  --since        ISO date (YYYY-MM-DD) — overrides definition's since
+  --until        ISO date (YYYY-MM-DD) — overrides definition's until
+
+Output (one row per person):
+  person_id, name, given_names, family_names, organizations,
+  rebelity_total, rebelity_possible, rebelity,
+  since, until, extras
+
+Vote semantics (from definition):
+  yes_options     → vote_value = +1, active = +1
+  no_options      → vote_value = -1, active = -1
+  other present   → vote_value = -1 (counts against for direction), active = 0
+  absent_options  → vote_value =  0, not present
+
+Group direction = sign(sum of vote_values for group members in that event).
+Rebelity denominator = vote events where group had a clear direction (≠ 0),
+  regardless of whether the MP was present.
+"""
+
+import argparse
+import csv
+import json
+import sys
+from datetime import date, datetime
+from pathlib import Path
+
+import jsonschema
+
+
+# ── Schema paths ───────────────────────────────────────────────────────────────
+
+_SCHEMA_BASE = Path(__file__).parent.parent.parent / "legislature-data-standard" / "dist"
+
+SCHEMA_PATHS = {
+    "definition":  _SCHEMA_BASE / "dt.analyses" / "rebelity-definition" / "latest" / "schemas" / "rebelity-definition.dt.analyses.json",
+    "votes_row":   _SCHEMA_BASE / "dt" / "latest" / "schemas" / "votes-table.dt.json",
+    "vote_events": _SCHEMA_BASE / "dt" / "latest" / "schemas" / "vote-events.dt.json",
+    "persons":     _SCHEMA_BASE / "dt.analyses" / "all-members" / "latest" / "schemas" / "all-members.dt.analyses.json",
+}
+
+
+def load_schema(key: str) -> dict:
+    path = SCHEMA_PATHS[key]
+    with open(path) as f:
+        return json.load(f)
+
+
+# ── Loaders ────────────────────────────────────────────────────────────────────
+
+def load_json_or_csv(path: str) -> list | dict:
+    p = Path(path)
+    suffix = p.suffix.lower()
+    if suffix == ".json":
+        with open(p) as f:
+            return json.load(f)
+    elif suffix == ".csv":
+        with open(p, newline="") as f:
+            return list(csv.DictReader(f))
+    else:
+        raise ValueError(f"Unsupported extension '{suffix}' for {path}")
+
+
+def load_definition(path: str) -> dict:
+    with open(path) as f:
+        data = json.load(f)
+    schema = load_schema("definition")
+    try:
+        jsonschema.validate(instance=data, schema=schema)
+    except jsonschema.ValidationError as e:
+        sys.exit(f"Definition '{path}' failed schema validation: {e.message}")
+    return data
+
+
+def load_vote_events(path: str) -> list[dict]:
+    data = load_json_or_csv(path)
+    if not isinstance(data, list):
+        sys.exit(f"vote_events '{path}' must be a JSON array")
+    schema = load_schema("vote_events")
+    try:
+        jsonschema.validate(instance=data, schema=schema)
+    except jsonschema.ValidationError as e:
+        sys.exit(f"vote_events '{path}' failed schema validation: {e.message}")
+    return data
+
+
+def load_votes(path: str) -> list[dict]:
+    data = load_json_or_csv(path)
+    if not isinstance(data, list):
+        sys.exit(f"votes '{path}' must be a list/array")
+    row_schema = load_schema("votes_row")
+    for i, row in enumerate(data):
+        try:
+            jsonschema.validate(instance=dict(row), schema=row_schema)
+        except jsonschema.ValidationError as e:
+            sys.exit(f"votes '{path}' row {i} failed schema validation: {e.message}")
+    return data
+
+
+def _parse_memberships_csv(raw: str) -> dict:
+    if not raw or raw.strip() in ("", "{}"):
+        return {}
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+
+
+def load_persons(path: str) -> list[dict]:
+    p = Path(path)
+    if p.suffix.lower() == ".csv":
+        with open(p, newline="") as f:
+            rows = []
+            for row in csv.DictReader(f):
+                person = dict(row)
+                for field in ("identifiers", "sources", "other_names"):
+                    if field in person and person[field]:
+                        try:
+                            person[field] = json.loads(person[field])
+                        except (json.JSONDecodeError, TypeError):
+                            person[field] = []
+                if "memberships" in person:
+                    person["memberships"] = _parse_memberships_csv(person["memberships"])
+                for k, v in person.items():
+                    if v == "":
+                        person[k] = None
+                rows.append(person)
+        data = rows
+    else:
+        with open(p) as f:
+            data = json.load(f)
+    if not isinstance(data, list):
+        sys.exit(f"persons '{path}' must be an array")
+    schema = load_schema("persons")
+    try:
+        jsonschema.validate(instance=data, schema=schema)
+    except jsonschema.ValidationError as e:
+        sys.exit(f"persons '{path}' failed schema validation: {e.message}")
+    return data
+
+
+# ── Date helpers ───────────────────────────────────────────────────────────────
+
+def parse_date_prefix(s: str | None) -> date | None:
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(s).date()
+    except ValueError:
+        try:
+            return date.fromisoformat(s[:10])
+        except ValueError:
+            return None
+
+
+def in_date_range(d: date | None, since: date | None, until: date | None) -> bool:
+    if d is None:
+        return True
+    if since is not None and d < since:
+        return False
+    if until is not None and d > until:
+        return False
+    return True
+
+
+# ── Group membership lookup ────────────────────────────────────────────────────
+
+def build_group_memberships(persons: list[dict]) -> dict[str, list[tuple]]:
+    """Returns {person_id: [(group_id, start_date, end_date), ...]} sorted by start desc."""
+    result: dict[str, list[tuple]] = {}
+    for p in persons:
+        pid = p.get("id") or p.get("person_id", "")
+        groups = (p.get("memberships") or {}).get("groups") or []
+        entries = []
+        for g in groups:
+            gid = g.get("id")
+            if not gid:
+                continue
+            entries.append((gid, parse_date_prefix(g.get("start_date")), parse_date_prefix(g.get("end_date"))))
+        entries.sort(key=lambda t: t[1] or date.min, reverse=True)
+        result[pid] = entries
+    return result
+
+
+def get_group_at_date(person_id: str, event_date: date | None,
+                      group_memberships: dict[str, list[tuple]]) -> str | None:
+    for (gid, start, end) in group_memberships.get(person_id, []):
+        if event_date is not None:
+            if start is not None and event_date < start:
+                continue
+            if end is not None and event_date > end:
+                continue
+        return gid
+    return None
+
+
+# ── Vote value helpers ─────────────────────────────────────────────────────────
+
+def vote_value(option: str, yes_opts: set[str], no_opts: set[str], present_opts: set[str]) -> int:
+    """
+    +1 for yes, -1 for no or other-present (abstain), 0 for absent.
+    Abstaining counts against for group direction purposes.
+    """
+    if option in yes_opts:
+        return 1
+    if option in no_opts:
+        return -1
+    if option in present_opts:
+        return -1
+    return 0
+
+
+def vote_value_active(option: str, yes_opts: set[str], no_opts: set[str]) -> int:
+    """Active vote: +1 yes, -1 no, 0 anything else."""
+    if option in yes_opts:
+        return 1
+    if option in no_opts:
+        return -1
+    return 0
+
+
+# ── Core calculation ───────────────────────────────────────────────────────────
+
+def calculate_rebelity(
+    definition: dict,
+    vote_events: list[dict],
+    votes: list[dict],
+    persons: list[dict],
+    since_override: date | None,
+    until_override: date | None,
+) -> list[dict]:
+
+    since_date = since_override or parse_date_prefix(definition.get("since"))
+    until_date = until_override or parse_date_prefix(definition.get("until"))
+    present_opts = set(definition["present_options"])
+    yes_opts = set(definition["yes_options"])
+    no_opts  = set(definition["no_options"])
+
+    # Filter valid vote events in date range
+    valid_events: dict[str, date | None] = {}
+    for ev in vote_events:
+        if ev.get("status", "valid") in ("invalid", "test"):
+            continue
+        ev_date = parse_date_prefix(ev.get("start_date"))
+        if in_date_range(ev_date, since_date, until_date):
+            valid_events[ev["id"]] = ev_date
+
+    # Index votes by event and by person
+    votes_by_event: dict[str, list[tuple[str, str]]] = {}
+    person_vote: dict[str, dict[str, str]] = {}
+    for row in votes:
+        eid = row["vote_event_id"]
+        if eid not in valid_events:
+            continue
+        pid, opt = row["voter_id"], row["option"]
+        votes_by_event.setdefault(eid, []).append((pid, opt))
+        person_vote.setdefault(pid, {})[eid] = opt
+
+    group_memberships = build_group_memberships(persons)
+
+    # Compute group direction per (event, group)
+    group_direction: dict[tuple[str, str], int] = {}
+    for eid, ev_date in valid_events.items():
+        group_sums: dict[str, int] = {}
+        for (pid, opt) in votes_by_event.get(eid, []):
+            val = vote_value(opt, yes_opts, no_opts, present_opts)
+            gid = get_group_at_date(pid, ev_date, group_memberships)
+            if gid:
+                group_sums[gid] = group_sums.get(gid, 0) + val
+        for gid, s in group_sums.items():
+            group_direction[(eid, gid)] = 1 if s > 0 else (-1 if s < 0 else 0)
+
+    # Build output
+    output: list[dict] = []
+    for person in persons:
+        pid = person.get("id") or person.get("person_id", "")
+        rebelity_total = 0
+        rebelity_possible = 0
+        p_votes = person_vote.get(pid, {})
+
+        for eid, ev_date in valid_events.items():
+            gid = get_group_at_date(pid, ev_date, group_memberships)
+            if not gid:
+                continue
+            gdir = group_direction.get((eid, gid), 0)
+            if gdir == 0:
+                continue
+            rebelity_possible += 1
+            opt = p_votes.get(eid)
+            if opt is not None:
+                active = vote_value_active(opt, yes_opts, no_opts)
+                if active * gdir == -1:
+                    rebelity_total += 1
+
+        row: dict = {
+            "person_id":         pid,
+            "rebelity_total":    rebelity_total,
+            "rebelity_possible": rebelity_possible,
+            "rebelity":          round(rebelity_total / rebelity_possible, 6) if rebelity_possible > 0 else None,
+        }
+
+        if person.get("name"):
+            row["name"] = person["name"]
+        if person.get("given_names") or person.get("given_name"):
+            given = person.get("given_names") or [person["given_name"]]
+            if isinstance(given, str):
+                given = [g.strip() for g in given.split(",") if g.strip()]
+            if given:
+                row["given_names"] = given
+        if person.get("family_names") or person.get("family_name"):
+            family = person.get("family_names") or [person["family_name"]]
+            if isinstance(family, str):
+                family = [f.strip() for f in family.split(",") if f.strip()]
+            if family:
+                row["family_names"] = family
+
+        memberships = person.get("memberships") or {}
+        orgs = []
+        for classification, key in [("group", "groups"), ("candidate_list", "candidate_list"), ("constituency", "constituency")]:
+            for g in (memberships.get(key) or []):
+                if not g.get("id"):
+                    continue
+                org: dict = {"id": g["id"], "classification": classification}
+                if g.get("name"):
+                    org["name"] = g["name"]
+                if g.get("start_date"):
+                    org["since"] = g["start_date"][:10]
+                if g.get("end_date"):
+                    org["until"] = g["end_date"][:10]
+                orgs.append(org)
+        if orgs:
+            row["organizations"] = orgs
+
+        if since_date is not None:
+            row["since"] = since_date.isoformat()
+        if until_date is not None:
+            row["until"] = until_date.isoformat()
+
+        extras: dict = {}
+        if person.get("image"):
+            extras["image"] = person["image"]
+        if extras:
+            row["extras"] = extras
+
+        output.append(row)
+
+    return output
+
+
+# ── Entry point ────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--definition",  required=True)
+    parser.add_argument("--votes",       required=True)
+    parser.add_argument("--vote_events", required=True)
+    parser.add_argument("--persons",     required=True)
+    parser.add_argument("--output",      required=True)
+    parser.add_argument("--since",       default=None)
+    parser.add_argument("--until",       default=None)
+    args = parser.parse_args()
+
+    since_override = parse_date_prefix(args.since)
+    until_override = parse_date_prefix(args.until)
+
+    print("Loading definition...",  file=sys.stderr)
+    definition = load_definition(args.definition)
+    print("Loading vote_events...", file=sys.stderr)
+    vote_events = load_vote_events(args.vote_events)
+    print("Loading votes...",       file=sys.stderr)
+    votes = load_votes(args.votes)
+    print("Loading persons...",     file=sys.stderr)
+    persons = load_persons(args.persons)
+    print("Calculating...",         file=sys.stderr)
+    output = calculate_rebelity(definition, vote_events, votes, persons, since_override, until_override)
+
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w") as f:
+        json.dump(output, f, ensure_ascii=False, indent=2)
+    print(f"Done. Wrote {len(output)} records to {args.output}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/rebelity/tests/test_rebelity.py
+++ b/rebelity/tests/test_rebelity.py
@@ -1,0 +1,224 @@
+"""
+Tests for the rebelity analysis.
+
+Run with:
+    python -m pytest legislature-data-analyses/rebelity/tests/
+or from the rebelity directory:
+    python -m pytest tests/
+"""
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+# ── Path constants ─────────────────────────────────────────────────────────────
+
+REPO_ROOT = Path(__file__).parent.parent.parent.parent  # legislature-data/
+REBELITY_SCRIPT = Path(__file__).parent.parent / "rebelity.py"
+
+# Test data paths (CZ PSP 2025-202x)
+_LEGISLATURE    = REPO_ROOT / "legislatures" / "cz-psp-data-2025-202x"
+TEST_DEFINITION  = _LEGISLATURE / "analyses" / "rebelity" / "rebelity_definition.json"
+TEST_VOTES       = _LEGISLATURE / "work" / "standard" / "votes.csv"
+TEST_VOTE_EVENTS = _LEGISLATURE / "work" / "standard" / "vote_events.json"
+TEST_PERSONS     = _LEGISLATURE / "analyses" / "all-members" / "outputs" / "all_members.json"
+
+# Output schema path
+_SCHEMA_BASE = REPO_ROOT / "legislature-data-standard" / "dist"
+OUTPUT_SCHEMA_PATH = _SCHEMA_BASE / "dt.analyses" / "rebelity" / "latest" / "schemas" / "rebelity.dt.analyses.json"
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def run_script(*extra_args, output_path: Path | None = None) -> tuple[int, str, str, list[dict] | None]:
+    """Run the rebelity script and return (returncode, stdout, stderr, parsed_output)."""
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tmp:
+        out = Path(tmp.name) if output_path is None else output_path
+
+    cmd = [
+        sys.executable, str(REBELITY_SCRIPT),
+        "--definition",  str(TEST_DEFINITION),
+        "--votes",       str(TEST_VOTES),
+        "--vote_events", str(TEST_VOTE_EVENTS),
+        "--persons",     str(TEST_PERSONS),
+        "--output",      str(out),
+        *extra_args,
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    data = None
+    if result.returncode == 0 and out.exists():
+        with open(out) as f:
+            data = json.load(f)
+    return result.returncode, result.stdout, result.stderr, data
+
+
+@pytest.fixture(scope="module")
+def output_data() -> list[dict]:
+    """Run the script once and return the output for all tests in this module."""
+    rc, stdout, stderr, data = run_script()
+    assert rc == 0, f"Script failed:\nSTDOUT: {stdout}\nSTDERR: {stderr}"
+    assert data is not None, "No output data produced"
+    return data
+
+
+@pytest.fixture(scope="module")
+def definition() -> dict:
+    with open(TEST_DEFINITION) as f:
+        return json.load(f)
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────────
+
+class TestOutputNotEmpty:
+    def test_has_persons(self, output_data):
+        """Output must contain at least one person."""
+        assert len(output_data) > 0, "Output is empty – expected at least one rebelity record"
+
+    def test_has_many_persons(self, output_data):
+        """Sanity check: Czech parliament has ~200 members."""
+        assert len(output_data) >= 100, f"Expected >=100 records, got {len(output_data)}"
+
+
+class TestOutputSchema:
+    def test_validates_against_schema(self, output_data):
+        """Output must validate against rebelity.dt.analyses JSON schema."""
+        with open(OUTPUT_SCHEMA_PATH) as f:
+            schema = json.load(f)
+        jsonschema.validate(instance=output_data, schema=schema)
+
+    def test_required_fields_present(self, output_data):
+        """Every row must have person_id, rebelity_total, rebelity_possible."""
+        for i, row in enumerate(output_data):
+            for field in ("person_id", "rebelity_total", "rebelity_possible"):
+                assert field in row, f"Row {i} missing required field '{field}'"
+
+
+class TestRebelityCounts:
+    def test_counts_non_negative(self, output_data):
+        """rebelity_total and rebelity_possible must be non-negative integers."""
+        for row in output_data:
+            assert row["rebelity_total"] >= 0
+            assert row["rebelity_possible"] >= 0
+
+    def test_total_le_possible(self, output_data):
+        """rebelity_total must not exceed rebelity_possible."""
+        for row in output_data:
+            assert row["rebelity_total"] <= row["rebelity_possible"], (
+                f"Person {row['person_id']}: rebelity_total ({row['rebelity_total']}) "
+                f"> rebelity_possible ({row['rebelity_possible']})"
+            )
+
+    def test_rebelity_rate_range(self, output_data):
+        """rebelity must be between 0 and 1 inclusive (or null when possible=0)."""
+        for row in output_data:
+            rb = row.get("rebelity")
+            if rb is not None:
+                assert 0.0 <= rb <= 1.0, (
+                    f"Person {row['person_id']}: rebelity {rb} out of [0,1]"
+                )
+
+    def test_rebelity_null_when_possible_zero(self, output_data):
+        """If rebelity_possible == 0, rebelity must be null."""
+        for row in output_data:
+            if row["rebelity_possible"] == 0:
+                assert row.get("rebelity") is None, (
+                    f"Person {row['person_id']}: rebelity should be null when possible=0"
+                )
+
+    def test_rebelity_consistent(self, output_data):
+        """rebelity must equal rebelity_total / rebelity_possible (within tolerance)."""
+        for row in output_data:
+            possible = row["rebelity_possible"]
+            rb = row.get("rebelity")
+            if possible > 0:
+                expected = row["rebelity_total"] / possible
+                assert rb is not None
+                assert abs(rb - round(expected, 6)) < 1e-9, (
+                    f"Person {row['person_id']}: rebelity {rb} != {expected}"
+                )
+
+    def test_possible_varies_across_persons(self, output_data):
+        """rebelity_possible should differ across persons."""
+        possibles = {row["rebelity_possible"] for row in output_data}
+        assert len(possibles) > 1, (
+            "rebelity_possible is identical for all persons – expected variation"
+        )
+
+
+class TestPersonCoverage:
+    def test_all_input_persons_in_output(self, output_data):
+        """Every person from the persons input must appear in the output."""
+        with open(TEST_PERSONS) as f:
+            persons = json.load(f)
+        input_ids = {p["id"] for p in persons}
+        output_ids = {row["person_id"] for row in output_data}
+        missing = input_ids - output_ids
+        assert missing == set(), f"These persons are missing from output: {missing}"
+
+    def test_no_duplicate_person_ids(self, output_data):
+        """Each person_id must appear at most once in the output."""
+        ids = [row["person_id"] for row in output_data]
+        duplicates = {pid for pid in ids if ids.count(pid) > 1}
+        assert duplicates == set(), f"Duplicate person_ids in output: {duplicates}"
+
+    def test_no_extra_persons_in_output(self, output_data):
+        """Output should not contain persons that were not in the persons input."""
+        with open(TEST_PERSONS) as f:
+            persons = json.load(f)
+        input_ids = {p["id"] for p in persons}
+        output_ids = {row["person_id"] for row in output_data}
+        extra = output_ids - input_ids
+        assert extra == set(), f"Output contains persons not in input: {extra}"
+
+
+class TestOrganizations:
+    def test_organization_ids_are_strings(self, output_data):
+        """All organization entries must have a non-empty string id."""
+        for row in output_data:
+            for org in row.get("organizations", []):
+                assert isinstance(org["id"], str) and org["id"], (
+                    f"Person {row['person_id']}: org with invalid id: {org}"
+                )
+
+
+class TestExtras:
+    def test_image_url_when_present(self, output_data):
+        """If extras.image is set it must be a non-empty string."""
+        for row in output_data:
+            extras = row.get("extras") or {}
+            image = extras.get("image")
+            if image is not None:
+                assert isinstance(image, str) and image, (
+                    f"Person {row['person_id']}: extras.image must be a non-empty string"
+                )
+
+    def test_some_persons_have_image(self, output_data):
+        """At least one person should carry an image URL from the persons input."""
+        images = [
+            row["extras"]["image"]
+            for row in output_data
+            if (row.get("extras") or {}).get("image")
+        ]
+        assert len(images) > 0, "No person has an image URL – check that persons input includes 'image' fields"
+
+
+class TestDateOverride:
+    def test_since_override_filters_events(self):
+        """--since flag should reduce or maintain the number of vote events counted."""
+        _, _, _, data_all = run_script()
+        _, _, _, data_since = run_script("--since", "2026-01-01")
+        assert data_since is not None
+
+        # Persons with data_since should have rebelity_possible <= full run
+        id_to_all = {r["person_id"]: r for r in data_all}
+        for row in data_since:
+            pid = row["person_id"]
+            if pid in id_to_all:
+                assert row["rebelity_possible"] <= id_to_all[pid]["rebelity_possible"], (
+                    f"Person {pid}: possible increased with --since filter"
+                )


### PR DESCRIPTION
## Summary

- Replaces the previous combined `rebelity-govity` analysis with two independent analyses: **rebelity** and **govity**
- `yes_options` / `no_options` are now **lists of strings** in the definition schema (allowing multiple option values per direction, e.g. `["no", "no_with_explanation"]`)
- Each analysis has its own script, Flourish output formatter, and pytest test suite

## Changes

**`rebelity/`**
- `rebelity.py` — calculates per-member rate of voting against own group's majority; group direction computed from all members' vote values (abstain counts against direction)
- `outputs/output_flourish_table.py` — produces Flourish-ready CSV
- `tests/test_rebelity.py` — 17 tests (all passing)
- `.gitignore`

**`govity/`**
- `govity.py` — calculates per-member rate of voting with the government when present; government defined by `government_groups` (org IDs) and optional `government_members` (person IDs)
- `outputs/output_flourish_table.py` — produces Flourish-ready CSV
- `tests/test_govity.py` — 18 tests including government-members high-govity sanity check (all passing)
- `.gitignore`

## Test plan

- [x] `python -m pytest legislature-data-analyses/rebelity/tests/` — 17 passed
- [x] `python -m pytest legislature-data-analyses/govity/tests/` — 18 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)